### PR TITLE
Fix RouterV2 on-chain balance accounting

### DIFF
--- a/contracts/v2/router/ITermMaxRouterV2.sol
+++ b/contracts/v2/router/ITermMaxRouterV2.sol
@@ -15,7 +15,7 @@ struct SwapPath {
     /// @notice If true, input amount will using balance onchain, otherwise using the input amount from sender
     bool useBalanceOnchain;
     /// @notice If uint's adapter is address(0), it means transfer the input token to recipient directly
-    /// @notice If uint's adapter token in equals to token out, the unit will be skipped
+    /// @notice If uint's adapter token in equals to token out, the unit will be skipped unless it is the final unit
     SwapUnit[] units;
 }
 

--- a/contracts/v2/router/TermMaxRouterV2.sol
+++ b/contracts/v2/router/TermMaxRouterV2.sol
@@ -116,17 +116,76 @@ contract TermMaxRouterV2 is
 
     function _executeSwapPaths(SwapPath[] memory paths) internal returns (uint256[] memory netTokenOuts) {
         netTokenOuts = new uint256[](paths.length);
+        uint256 maxTrackedTokens;
+        for (uint256 i = 0; i < paths.length; ++i) {
+            maxTrackedTokens += paths[i].units.length * 2;
+        }
+        address[] memory trackedTokens = new address[](maxTrackedTokens);
+        uint256[] memory initialBalances = new uint256[](maxTrackedTokens);
+        uint256 trackedTokenCount;
+
         for (uint256 i = 0; i < paths.length; ++i) {
             SwapPath memory path = paths[i];
+            trackedTokenCount = _trackSwapUnitBalances(path.units, trackedTokens, initialBalances, trackedTokenCount);
             if (path.useBalanceOnchain) {
                 uint256 balanceOnChain = IERC20(path.units[0].tokenIn).balanceOf(address(this));
-                netTokenOuts[i] = _executeSwapUnits(path.recipient, balanceOnChain, path.units);
+                uint256 initialBalance =
+                    _getTrackedInitialBalance(path.units[0].tokenIn, trackedTokens, initialBalances, trackedTokenCount);
+                netTokenOuts[i] = _executeSwapUnits(path.recipient, balanceOnChain - initialBalance, path.units);
             } else {
                 IERC20(path.units[0].tokenIn).safeTransferFrom(_msgSender(), address(this), path.inputAmount);
                 netTokenOuts[i] = _executeSwapUnits(path.recipient, path.inputAmount, path.units);
             }
         }
         return netTokenOuts;
+    }
+
+    function _trackSwapUnitBalances(
+        SwapUnit[] memory units,
+        address[] memory trackedTokens,
+        uint256[] memory initialBalances,
+        uint256 trackedTokenCount
+    ) internal view returns (uint256) {
+        for (uint256 i = 0; i < units.length; ++i) {
+            trackedTokenCount =
+                _trackTokenBalance(units[i].tokenIn, trackedTokens, initialBalances, trackedTokenCount);
+            trackedTokenCount =
+                _trackTokenBalance(units[i].tokenOut, trackedTokens, initialBalances, trackedTokenCount);
+        }
+        return trackedTokenCount;
+    }
+
+    function _trackTokenBalance(
+        address token,
+        address[] memory trackedTokens,
+        uint256[] memory initialBalances,
+        uint256 trackedTokenCount
+    ) internal view returns (uint256) {
+        if (token == address(0)) {
+            return trackedTokenCount;
+        }
+        for (uint256 i = 0; i < trackedTokenCount; ++i) {
+            if (trackedTokens[i] == token) {
+                return trackedTokenCount;
+            }
+        }
+        trackedTokens[trackedTokenCount] = token;
+        initialBalances[trackedTokenCount] = IERC20(token).balanceOf(address(this));
+        return trackedTokenCount + 1;
+    }
+
+    function _getTrackedInitialBalance(
+        address token,
+        address[] memory trackedTokens,
+        uint256[] memory initialBalances,
+        uint256 trackedTokenCount
+    ) internal pure returns (uint256) {
+        for (uint256 i = 0; i < trackedTokenCount; ++i) {
+            if (trackedTokens[i] == token) {
+                return initialBalances[i];
+            }
+        }
+        return 0;
     }
 
     function _executeSwapUnits(address recipient, uint256 inputAmt, SwapUnit[] memory units)
@@ -138,6 +197,9 @@ contract TermMaxRouterV2 is
         }
         for (uint256 i = 0; i < units.length; ++i) {
             if (units[i].tokenIn == units[i].tokenOut) {
+                if (i == units.length - 1) {
+                    IERC20(units[i].tokenIn).safeTransfer(recipient, inputAmt);
+                }
                 continue;
             }
             if (units[i].adapter == address(0)) {

--- a/test/v2/RouterV2.t.sol
+++ b/test/v2/RouterV2.t.sol
@@ -361,6 +361,84 @@ contract RouterTestV2 is Test {
         vm.stopPrank();
     }
 
+    function testSwapTokensCannotDrainPrefundedRouterBalance() public {
+        address recipient = vm.randomAddress();
+        uint256 prefundedBalance = 100e8;
+        res.debt.mint(address(res.router), prefundedBalance);
+
+        SwapUnit[] memory swapUnits = new SwapUnit[](1);
+        swapUnits[0] =
+            SwapUnit({adapter: address(0), tokenIn: address(res.debt), tokenOut: address(0), swapData: bytes("")});
+
+        SwapPath[] memory swapPaths = new SwapPath[](1);
+        swapPaths[0] =
+            SwapPath({units: swapUnits, recipient: recipient, inputAmount: 0, useBalanceOnchain: true});
+
+        uint256[] memory netOutputs = res.router.swapTokens(swapPaths);
+
+        assertEq(netOutputs[0], 0);
+        assertEq(res.debt.balanceOf(recipient), 0);
+        assertEq(res.debt.balanceOf(address(res.router)), prefundedBalance);
+    }
+
+    function testSwapTokensCanUseBalanceFromCurrentCall() public {
+        uint256 amount = 100e8;
+        res.debt.mint(sender, amount);
+
+        vm.startPrank(sender);
+        res.debt.approve(address(res.router), amount);
+
+        SwapPath[] memory swapPaths = new SwapPath[](2);
+        SwapUnit[] memory depositUnits = new SwapUnit[](1);
+        depositUnits[0] = SwapUnit({
+            adapter: address(0),
+            tokenIn: address(res.debt),
+            tokenOut: address(res.debt),
+            swapData: bytes("")
+        });
+        swapPaths[0] =
+            SwapPath({units: depositUnits, recipient: address(res.router), inputAmount: amount, useBalanceOnchain: false});
+
+        SwapUnit[] memory withdrawUnits = new SwapUnit[](1);
+        withdrawUnits[0] =
+            SwapUnit({adapter: address(0), tokenIn: address(res.debt), tokenOut: address(0), swapData: bytes("")});
+        swapPaths[1] = SwapPath({units: withdrawUnits, recipient: sender, inputAmount: 0, useBalanceOnchain: true});
+
+        uint256[] memory netOutputs = res.router.swapTokens(swapPaths);
+
+        assertEq(netOutputs[0], amount);
+        assertEq(netOutputs[1], amount);
+        assertEq(res.debt.balanceOf(sender), amount);
+        assertEq(res.debt.balanceOf(address(res.router)), 0);
+        vm.stopPrank();
+    }
+
+    function testSameTokenSwapSendsFinalAmountToRecipient() public {
+        uint256 amount = 100e8;
+        res.debt.mint(sender, amount);
+
+        vm.startPrank(sender);
+        res.debt.approve(address(res.router), amount);
+
+        SwapUnit[] memory swapUnits = new SwapUnit[](1);
+        swapUnits[0] = SwapUnit({
+            adapter: address(0),
+            tokenIn: address(res.debt),
+            tokenOut: address(res.debt),
+            swapData: bytes("")
+        });
+
+        SwapPath[] memory swapPaths = new SwapPath[](1);
+        swapPaths[0] = SwapPath({units: swapUnits, recipient: sender, inputAmount: amount, useBalanceOnchain: false});
+
+        uint256[] memory netOutputs = res.router.swapTokens(swapPaths);
+
+        assertEq(netOutputs[0], amount);
+        assertEq(res.debt.balanceOf(sender), amount);
+        assertEq(res.debt.balanceOf(address(res.router)), 0);
+        vm.stopPrank();
+    }
+
     function testLeverageFromToken(bool isV1) public {
         vm.startPrank(sender);
 
@@ -1146,8 +1224,7 @@ contract RouterTestV2 is Test {
 
         // Because our mock simply transfers tokenIn to recipient, netOutputs[0] should equal amountIn
         assertEq(netOutputs[0], amountIn);
-        // Sender's debt balance should be zero
-        assertEq(res.debt.balanceOf(sender), 0);
+        assertEq(res.debt.balanceOf(sender), amountIn);
 
         vm.stopPrank();
     }


### PR DESCRIPTION
## Summary
- Track initial router token balances for each swap batch and make `useBalanceOnchain` consume only balances produced during the current call.
- Forward the final amount to the recipient when the last swap unit is a same-token no-op, preventing user funds from being stranded in the router.
- Add regression coverage for prefunded router balances, current-call balances, and final same-token units.

Fixes #28

## Tests
- `forge test --match-contract RouterTestV2 -vv`
- `git diff --check`