### PR TITLE
Restrict guardian replacement revocation to owner

### DIFF
--- a/contracts/v2/vault/TermMaxVaultV2.sol
+++ b/contracts/v2/vault/TermMaxVaultV2.sol
@@ -597,7 +597,7 @@ contract TermMaxVaultV2 is
         emit VaultEvents.RevokePendingTimelock(_msgSender());
     }
 
-    function revokePendingGuardian() external virtual onlyGuardianRole {
+    function revokePendingGuardian() external virtual onlyOwner {
         delete _pendingGuardian;
 
         emit VaultEvents.RevokePendingGuardian(_msgSender());

--- a/test/v2/VaultV2.t.sol
+++ b/test/v2/VaultV2.t.sol
@@ -207,6 +207,11 @@ contract VaultTestV2 is Test {
         vault.submitGuardian(nextGuardian);
 
         vm.prank(newGuardian);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, newGuardian));
+        vault.revokePendingGuardian();
+        assertEq(vault.pendingGuardian().value, nextGuardian);
+
+        vm.prank(deployer);
         vault.revokePendingGuardian();
         assertEq(vault.pendingGuardian().value, address(0));
 


### PR DESCRIPTION
## Summary
- Restrict `TermMaxVaultV2.revokePendingGuardian()` to the vault owner so the current guardian cannot cancel its own replacement.
- Keep owner/AccessManager revocation available for governance-managed pending guardian changes.
- Extend the role-management test to assert the old guardian reverts and the owner can still revoke.

Fixes #27

## Tests
- `forge test --match-contract VaultTestV2 --match-test testRoleManagement -vv`
- `forge test --match-contract AccessManagerTestV2 --match-test testRevokeVaultPendingValues -vv`
- `forge test --match-contract AccessManagerTestV2 -vv`
- `forge test --match-contract VaultTestV2 --match-test testRoleManagement|test_RevertSetGuardian -vv`
- `git diff --check`